### PR TITLE
Fix to Bug 45

### DIFF
--- a/src/dowel/logger.py
+++ b/src/dowel/logger.py
@@ -135,6 +135,7 @@ import abc
 import contextlib
 import warnings
 
+from dowel.tabular_input import TabularInput
 from dowel.utils import colorize
 
 
@@ -196,7 +197,9 @@ class Logger:
         type (defined in the types_accepted property).
 
         :param data: Data to be logged. This can be any type specified in the
-         types_accepted property of any of the logger outputs.
+         types_accepted property of any of the logger outputs. If the data is
+         a TabularInput instance, it won't be deleted, thus to prevent spill
+         over from unupdated keys, its values need be reset.
         """
         if not self._outputs:
             self._warn('No outputs have been added to the logger.')
@@ -206,6 +209,8 @@ class Logger:
             if isinstance(data, output.types_accepted):
                 output.record(data, prefix=self._prefix_str)
                 at_least_one_logged = True
+        if at_least_one_logged and isinstance(data, TabularInput):
+            data.reset()
 
         if not at_least_one_logged:
             warning = (

--- a/src/dowel/simple_outputs.py
+++ b/src/dowel/simple_outputs.py
@@ -57,6 +57,7 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
     """
 
     def __init__(self, file_name, mode='w'):
+        self._file_name = file_name
         mkdir_p(os.path.dirname(file_name))
         # Open the log file in child class
         self._log_file = open(file_name, mode)

--- a/src/dowel/tabular_input.py
+++ b/src/dowel/tabular_input.py
@@ -35,6 +35,11 @@ class TabularInput:
         """
         self._dict[self._prefix_str + str(key)] = val
 
+    def reset(self):
+        """Reset values to the empty string"""
+        for k, v in self._dict.items():
+            self._dict[k] = ""
+
     def mark(self, key):
         """Mark key as recorded."""
         self._recorded.add(key)

--- a/src/dowel/tensor_board_output.py
+++ b/src/dowel/tensor_board_output.py
@@ -11,6 +11,7 @@ Note:
 """
 import functools
 import warnings
+from copy import deepcopy
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -85,6 +86,7 @@ class TensorBoardOutput(LogOutput):
             prefix(str): A prefix placed before a log entry in text outputs.
 
         """
+        data = deepcopy(data)
         if isinstance(data, TabularInput):
             self._waiting_for_dump.append(
                 functools.partial(self._record_tabular, data))

--- a/tests/dowel/test_dynamic_csv_headers.py
+++ b/tests/dowel/test_dynamic_csv_headers.py
@@ -1,0 +1,247 @@
+#from unittest import mock
+import os
+
+import pytest
+from flaky import flaky
+
+
+class TestDynamicHeaders:
+
+    def clean_start(self):
+        try:
+            os.remove('out.csv')
+            os.remove('out_temp.csv')
+        except OSError:
+            pass
+
+    def test_static_headers(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_dynamic_single_increase_end(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 0:
+                tabular.record('new_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+        
+        
+    @flaky(max_runs=3)
+    def test_dynamic_multi_increase_end(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 0:
+                tabular.record('n1_data', i)
+            if i > 10:
+                tabular.record('n2_data', i)
+                tabular.record('n3_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_dynamic_single_increase_with_decrease(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 0 and i < 7:
+                tabular.record('new_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+        
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_dynamic_multi_increase_with_decrease(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 0 and i < 7:
+                tabular.record('n1_data', i)
+            if i > 12:
+                tabular.record('n2_data', i)
+                tabular.record('n3_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_dynamic_overlap_increase_decrease(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 0 and i < 8:
+                tabular.record('n1_data', i)
+            if i > 4:
+                tabular.record('n2_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_static_tensorboard_compatibility(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+        logger.add_output(dowel.TensorBoardOutput('tensorboard_logdir'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+
+    @flaky(max_runs=3)
+    def test_dynamic_tensorboard_compatibility(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+        logger.add_output(dowel.TensorBoardOutput('tensorboard_logdir'))
+
+        for i in range(15):
+            logger.push_prefix('itr {} '.format(i))
+            
+            tabular.record('itr', i)
+            tabular.record('loss', 100.0 / (2 + i))
+
+            if i > 1:
+                tabular.record('new_data', i)
+
+            logger.log(tabular)
+
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()
+
+    @flaky(max_runs=3)
+    def test_no_log(self):
+        self.clean_start()
+        import dowel
+        from dowel import logger, tabular
+        logger.add_output(dowel.StdOutput())
+        logger.add_output(dowel.CsvOutput('out.csv'))
+
+        for i in range(4):
+            logger.push_prefix('itr {} '.format(i))
+
+            if i < 2:
+                tabular.record('itr', i)
+                tabular.record('loss', 100.0 / (2 + i))
+
+            logger.log(tabular)
+            logger.pop_prefix()
+            logger.dump_all()
+
+        tabular.clear()
+        logger.remove_all()


### PR DESCRIPTION
Fix for [Bug 45](https://github.com/rlworkgroup/dowel/issues/45)

Inconsistent header keys are handled. When a new key is introduced, the previous data is augmented line by line. In the logger, if data is a TabularInput instance, then it has its values emptied, with its keys remaining so that there is no data bleed when a key is omitted in the future. Tensorboard incompatibility is an issue as tensorboard does not accept the empty character (or string) as a legal numpy scalar.

Nine tests have been provided to cover the various circumstances:

No change in keys
Single increase in keys with consistent future usage
Multiple increase in keys with consistent future usage
Single increase in keys with inconsistent future usage
Multiple increase in keys with inconsistent future usage
Overlapping increase in keys with immediate inconsistency
Static keys - tensorboard incompatibility test
Dynamic keys - tensorboard incompatibility test
Empty tabulation test
Note: I have left the comment structure to be consistent with the preexisting code.